### PR TITLE
Modify some texts, increase map viewport and add items opacity management

### DIFF
--- a/data/setup.otml
+++ b/data/setup.otml
@@ -3,7 +3,7 @@ game
   last-supported-version: 1321
   
   map
-    viewport: 16 9
+    viewport: 32 18
     max-z: 15
     sea-floor: 7
     underground-floor: 8

--- a/data/setup.otml
+++ b/data/setup.otml
@@ -3,7 +3,7 @@ game
   last-supported-version: 1321
   
   map
-    viewport: 8 6
+    viewport: 16 9
     max-z: 15
     sea-floor: 7
     underground-floor: 8

--- a/init.lua
+++ b/init.lua
@@ -6,9 +6,9 @@ Services = {
     --updater = "http://localhost/api/updater.php",
 }
 
-g_app.setName("OTClient - Redemption");
-g_app.setCompactName("otclient");
-g_app.setOrganizationName("otcr");
+g_app.setName("Mythria");
+g_app.setCompactName("mythria");
+g_app.setOrganizationName("mythria");
 
 g_app.hasUpdater = function()
     return (Services.updater and Services.updater ~= "" and g_modules.getModule("updater"))

--- a/modules/client_background/background.otui
+++ b/modules/client_background/background.otui
@@ -18,7 +18,7 @@ Panel
     text-auto-resize: true
     margin-top: 50
     color: #e98d02
-    text: OTCLient Redemption
+    text: Mythria
     font: verdana-11px-rounded
     font-scale: 4
     shader: Map - Party

--- a/modules/game_features/features.lua
+++ b/modules/game_features/features.lua
@@ -48,6 +48,11 @@ controller:registerEvents(g_game, {
         end
 
         if version >= 860 then
+            g_game.enableFeature(GameSpritesU32); -- Enable extended sprites
+            g_game.enableFeature(GameMagicEffectU16); -- Enable increased effects
+            g_game.enableFeature(GameDistanceEffectU16);
+            g_game.enableFeature(GameExtendedOpcode);
+            g_game.enableFeature(GameChangeMapAwareRange);
             g_game.enableFeature(GameAttackSeq);
         end
 

--- a/modules/game_things/things.lua
+++ b/modules/game_things/things.lua
@@ -74,4 +74,5 @@ function load(version)
             onClientVersionChange = load
         })
     end
+    g_things.loadOtml('things.otml')
 end

--- a/modules/game_things/things.otml
+++ b/modules/game_things/things.otml
@@ -1,0 +1,4 @@
+items
+  622
+    opacity: 0.5
+    full-ground: false

--- a/src/client/gameconfig.h
+++ b/src/client/gameconfig.h
@@ -80,7 +80,7 @@ private:
     uint16_t m_lastSupportedVersion{ 1321 };
 
     // Map
-    Size m_mapViewPort{ 16,9 };
+    Size m_mapViewPort{ 32,18 };
     uint8_t m_mapMaxZ{ 15 };
     uint8_t m_mapSeaFloor{ 7 };
     uint8_t m_mapUndergroundFloorRange{ 2 };

--- a/src/client/gameconfig.h
+++ b/src/client/gameconfig.h
@@ -80,7 +80,7 @@ private:
     uint16_t m_lastSupportedVersion{ 1321 };
 
     // Map
-    Size m_mapViewPort{ 8,6 };
+    Size m_mapViewPort{ 16,9 };
     uint8_t m_mapMaxZ{ 15 };
     uint8_t m_mapSeaFloor{ 7 };
     uint8_t m_mapUndergroundFloorRange{ 2 };

--- a/src/framework/config.h
+++ b/src/framework/config.h
@@ -50,6 +50,6 @@
 #define SHOW_CHARACTER_LEVEL_RPC 1 // 1 to enable | 0 to disable
 #define SHOW_CHARACTER_WORLD_RPC 1 // 1 to enable | 0 to disable
 #define OFFLINE_RPC_TEXT "Selecting Character..." // Message at client startup | offline character
-#define STATE_RPC_TEXT "github.com/mehah/otclient" // State Text
+#define STATE_RPC_TEXT "github.com/mythriaot/otclient" // State Text
 #define RPC_LARGE_IMAGE "rpc-logo" // Large Image Name (Imported to API)
-#define RPC_LARGE_TEXT "OTClient - Redemption" // Large Text (Text showed at tooltip large image)
+#define RPC_LARGE_TEXT "Mythria" // Large Text (Text showed at tooltip large image)


### PR DESCRIPTION
## What I did

- Modified Discord RPC config (what will be shown in Discord when our game is running).
- Modified the login screen title and some other texts.
- Increased the viewport to 32 18.
- Enabled new features for version 860 and above in `game_features/features.lua` file.
- Added items opacity management. Now, you can simply set the opacity of an item in the map through the `modules/game_thing/things.otml` file.